### PR TITLE
incommon.cert doesn't seem to be created/needed and probably should be removed from the template

### DIFF
--- a/templates/apache-rails-application.j2
+++ b/templates/apache-rails-application.j2
@@ -14,7 +14,7 @@
 
    SSLCertificateFile /etc/pki/tls/certs/{{ web_server_name }}.crt
    SSLCertificateKeyFile /etc/pki/tls/certs/{{ web_server_name }}.key
-   SSLCertificateChainFile  /etc/pki/tls/certs/incommon.cert
+   # SSLCertificateChainFile  /etc/pki/tls/certs/incommon.cert
 
    {% if apache_virtualhost_lines %}
      {% for line in apache_virtualhost_lines %}


### PR DESCRIPTION
`incommon.cert` doesn't seem to be created/needed and having it in the template would cause an error in this role.